### PR TITLE
Silence the objc_weak_error warnings

### DIFF
--- a/GCXMulticastDNSKit/Discovery.swift
+++ b/GCXMulticastDNSKit/Discovery.swift
@@ -207,7 +207,11 @@ extension Discovery {
     fileprivate func stopSearchingAndResolving() {
         let _ = items?.map {
             $0.netServiceBrowser.stop()
-            let _ = $0.netServices.map { $0.stop() }
+            $0.netServiceBrowser.delegate = nil
+            let _ = $0.netServices.map {
+                $0.stop()
+                $0.delegate = nil
+            }
         }
         
         items = nil


### PR DESCRIPTION
There is a bug in NSNetService and NSNetServiceBrowser that keeps references to their weak delegates upon deallocation. This causes a warning to be printed in the debugger console. By setting the delegates explicitly to nil this can be circumvented.

Also the the rdar: https://openradar.appspot.com/28943305