### PR TITLE
Adds basic codecov support

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,5 @@
+ignore:
+        - "GCXMulticastDNSKitTests"
+
+coverage:
+        range: 70..100

--- a/GCXMulticastDNSKit.xcodeproj/xcshareddata/xcschemes/GCXMulticastDNSKit.xcscheme
+++ b/GCXMulticastDNSKit.xcodeproj/xcshareddata/xcschemes/GCXMulticastDNSKit.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/GCXMulticastDNSKitTests/GCXDiscoveryTests.swift
+++ b/GCXMulticastDNSKitTests/GCXDiscoveryTests.swift
@@ -114,6 +114,65 @@ class GCXDiscoveryTests: XCTestCase {
     }
 
     
+    func testNetServiceDelegateSuccessWithWrongNetService() {
+        service = NetService(domain: "", type: "_http._tcp", name: "GCXDNSKitTest", port: 10000 )
+        let discoveryConfiguration = DiscoveryConfiguration(serviceType: "_http._tcp", serviceNamePrefix: "GCXDNSKitTest")
+        guard let discovery = Discovery(with: [ discoveryConfiguration ], delegate: self) else {
+            XCTAssertTrue(false)
+            return
+        }
+        
+        XCTAssertNoThrow(discovery.netServiceDidResolveAddress(service!)
+, "should return early from delegate call when no item is found")
+        
+    }
+    
+    func testNetServiceDelegateDidNotResolveWithWrongNetService() {
+        service = NetService(domain: "", type: "_http._tcp", name: "GCXDNSKitTest", port: 10000 )
+        let discoveryConfiguration = DiscoveryConfiguration(serviceType: "_http._tcp", serviceNamePrefix: "GCXDNSKitTest")
+        guard let discovery = Discovery(with: [ discoveryConfiguration ], delegate: self) else {
+            XCTAssertTrue(false)
+            return
+        }
+        
+        XCTAssertNoThrow(discovery.netService(service!, didNotResolve: [ "SomeString": 3 ])
+            , "should return early from delegate call when no item is found")
+        
+    }
+    
+    func testNetServiceBrowserDelegateDidFindWithWrongNetServiceBrowser() {
+        let netserviceBrowser = NetServiceBrowser()
+        service = NetService(domain: "", type: "_http._tcp", name: "GCXDNSKitTest", port: 10000 )
+        
+        let discoveryConfiguration = DiscoveryConfiguration(serviceType: "_http._tcp", serviceNamePrefix: "GCXDNSKitTest")
+        guard let discovery = Discovery(with: [ discoveryConfiguration ], delegate: self) else {
+            XCTAssertTrue(false)
+            return
+        }
+        
+        
+        XCTAssertNoThrow(discovery.netServiceBrowser(netserviceBrowser, didFind: service!, moreComing: false)
+            , "should return early from delegate call when no item is found")
+        
+    }
+
+    func testNetServiceBrowserDelegateDidRemoveWithWrongNetServiceBrowser() {
+        let netserviceBrowser = NetServiceBrowser()
+        service = NetService(domain: "", type: "_http._tcp", name: "GCXDNSKitTest", port: 10000 )
+
+        let discoveryConfiguration = DiscoveryConfiguration(serviceType: "_http._tcp", serviceNamePrefix: "GCXDNSKitTest")
+        guard let discovery = Discovery(with: [ discoveryConfiguration ], delegate: self) else {
+            XCTAssertTrue(false)
+            return
+        }
+        
+       
+        XCTAssertNoThrow(discovery.netServiceBrowser(netserviceBrowser, didRemove: service!, moreComing: false)
+            , "should return early from delegate call when no item is found")
+        
+    }
+
+    
   
 
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # GCXMulticastDNSKit
- [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Release](https://img.shields.io/github/release/grandcentrix/GCXMulticastDNSKit.svg) [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage) [![Cocoapods compatible](https://img.shields.io/cocoapods/v/GCXMulticastDNSKit.svg)](https://cocoapods.org/) 	
+ [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Release](https://img.shields.io/github/release/grandcentrix/GCXMulticastDNSKit.svg) [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage) [![Cocoapods compatible](https://img.shields.io/cocoapods/v/GCXMulticastDNSKit.svg)](https://cocoapods.org/) [![codecov](https://codecov.io/gh/grandcentrix/GCXMulticastDNSKit/branch/master/graph/badge.svg)](https://codecov.io/gh/grandcentrix/GCXMulticastDNSKit)
+
 
 
 Multicast DNS framework for iOS


### PR DESCRIPTION
For a evaluation of [Codecov](https://codecov.io) I have added a configuration yml and enabled code coverage generation for the test target.
