### PR TITLE
Support SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,34 @@
+// swift-tools-version:5.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "GCXMulticastDNSKit",
+    platforms: [
+        .iOS(.v9),
+    ],
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "GCXMulticastDNSKit",
+            targets: ["GCXMulticastDNSKit"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "GCXMulticastDNSKit",
+            dependencies: [],
+            path: "GCXMulticastDNSKit"),
+        .testTarget(
+            name: "GCXMulticastDNSKitTests",
+            dependencies: ["GCXMulticastDNSKit"],
+            path: "GCXMulticastDNSKitTests"),
+    ],
+    swiftLanguageVersions: [.v5]
+)


### PR DESCRIPTION
Add `Package.swift` to support integration via SPM.

This requires a new release (tag) to work, however, I didn't touch the `.podspec` as I wasn't sure what the next version should be.